### PR TITLE
Use shields.io for travis badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Chadicus\Exceptions
-[![Build Status](https://travis-ci.org/chadicus/exceptions-php.png)](https://travis-ci.org/chadicus/exceptions-php)
+[![Build Status](http://img.shields.io/travis/chadicus/exceptions-php.svg?style=flat)](https://travis-ci.org/chadicus/exceptions-php)
 [![Scrutinizer Code Quality](http://img.shields.io/scrutinizer/g/chadicus/exceptions-php.svg?style=flat)](https://scrutinizer-ci.com/g/chadicus/exceptions-php/)
 [![Latest Stable Version](http://img.shields.io/packagist/v/chadicus/exceptions.svg?style=flat)](https://packagist.org/packages/chadicus/exceptions)
 [![Total Downloads](http://img.shields.io/packagist/dt/chadicus/exceptions.svg?style=flat)](https://packagist.org/packages/chadicus/exceptions)


### PR DESCRIPTION
This helps make the badges look consistent by using a single source for them.
